### PR TITLE
GitHub Actions: Explicitly disable symlinks on Windows and bump spdlog to v1.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,14 @@ jobs:
       run: |
         for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
 
+    # symlinks disabled are the default setting on Windows, but unfortunatly GitHub Actions enabled them 
+    # See: 
+    # * https://github.com/robotology/robotology-superbuild/issues/429
+    # * https://github.com/actions/virtual-environments/pull/1186  
+    - name: Disable Git symlinks on Windows 
+      if: contains(matrix.os, 'windows')
+      run: git config --global core.symlinks false
+
     # ============
     # DEPENDENCIES
     # ============

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
         # spdlog
         git clone https://github.com/gabime/spdlog
         cd spdlog
-        git checkout v1.6.0
+        git checkout v1.7.0
         mkdir -p build
         cd build
         cmake -A x64 -DSPDLOG_BUILD_SHARED:BOOL=ON -DSPDLOG_BUILD_EXAMPLE:BOOL=OFF -DSPDLOG_FMT_EXTERNAL:BOOL=ON -DBUILD_TESTING:BOOL=OFF -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..


### PR DESCRIPTION
Workaround for https://github.com/traversaro/drake-lite-cmake/issues/17 .